### PR TITLE
Fixed a problem with the NilCheck smell

### DIFF
--- a/lib/preek/smell_warning.rb
+++ b/lib/preek/smell_warning.rb
@@ -10,7 +10,7 @@ module Reek
     end
 
     def smell_string
-      "#{smell_method} #{@smell['message']} (#{@smell['subclass']}) at lines #{@location['lines']*','}"
+      "#{smell_method} #{@smell['message']} (#{@smell['subclass']}) at lines #{Array(@location['lines'])*','}"
     end
   end
 end

--- a/spec/preek_spec.rb
+++ b/spec/preek_spec.rb
@@ -74,5 +74,15 @@ describe Preek::Preek do
         output.should include("#loong_method", "#x")
       end
     end
+
+    context "when given file has NilCheck smell" do
+      let(:args){ [test_file('nil_check')] }
+      it "output contains 'NilCheck'" do
+        output.should include("NilCheck")
+      end
+      it "outputs the name of the file" do
+        output.should include(args[0])
+      end
+    end
   end
 end

--- a/spec/test_files/nil_check.rb
+++ b/spec/test_files/nil_check.rb
@@ -1,0 +1,12 @@
+#This class a nil check
+class NilCheck
+  def initialize(number)
+    @number = number
+  end
+
+  def nil_check
+    @number.times do |number|
+      next if number.nil?
+    end
+  end
+end


### PR DESCRIPTION
Reek has a single integer in the `@location['lines']` for NilCheck smells. "Fixed" by using the arrayification operator on it in the SmellWarning class
